### PR TITLE
add fireblocks support

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,3 +1,5 @@
 RPC_URL=https://custom-rpc-staging.silentdata.com/<your-token>
 NETWORK_NAME=SD
 CHAIN_ID=51966
+FIREBLOCKS_SECRET_KEY_PATH=fireblocks_secret.key
+FIREBLOCKS_API_KEY=<fireblocks-api-key>

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 .yarn
 .env
+fireblocks_secret.key
 
 hardhat/hardhat-sdr/package-lock.json
 hardhat/hardhat-sdr/node_modules

--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ cast --version
 
   Should be the value 51966
 
+- **FIREBLOCKS_API_KEY**
+
+  To get the FIREBLOCKS_API_KEY you should go to the Fireblocks dashboard (https://sandbox.fireblocks.io/v2/developer/api-users) and create an api user (with editor role) with sign permissions. Download the private key file generated for the user. 
+
+- **FIREBLOCKS_SECRET_KEY_PATH**
+
+  The private key file generated for the api user created. Default value is `fireblocks_secret.key`
+  The file should be copied and pasted in the `/app` folder
+
 
 # Important: Environment Setup
 
@@ -68,6 +77,13 @@ cast --version
 7) Open the created file **.env**
 8) On the first variable named **RPC_URL**, just replace **&lt;your-token&gt;** with your actual token copied from step 5.
 
+For Fireblocks
+1) Signup/Login at https://www.fireblocks.com/
+2) Go to Developer Center -> API users
+3) Add a new user (select Editor Role)
+4) Download the CSR private key file generated
+5) Paste the file in the `/app` folder 
+6) Check that the **FIREBLOCKS_SECRET_KEY_PATH** and the name of the file is the same
 
 # Installation 
 
@@ -241,4 +257,42 @@ const tx = await signer.sendTransaction({
   to: '<send-to-address>',
   value: ethers.parseUnits('0.001', 'ether'),
 });
+```
+
+## Using Fireblocks wallet
+```ts
+// config and init the fireblocks api sdk
+const FIREBLOCKS_API_KEY = process.env.FIREBLOCKS_API_KEY;
+const FIREBLOCKS_SECRET_KEY_PATH = process.env.FIREBLOCKS_SECRET_KEY_PATH;
+const FIREBLOCKS_SECRET_KEY = readFileSync(resolve(FIREBLOCKS_SECRET_KEY_PATH!), "utf-8");
+
+const fireblocks = new Fireblocks({
+  apiKey: FIREBLOCKS_API_KEY,
+  secretKey: FIREBLOCKS_SECRET_KEY,
+  basePath: BasePath.Sandbox,
+});
+
+// create the fireblocks signer with the asset and account selected
+const fireblocksSigner: FireblocksSigner = {
+  fireblocks,
+  assetId: fireblocksAssetId,
+  vaultAccountId: fireblocksVaultAccountId
+}
+// set the fireblocks signer
+provider.setSigner(fireblocksSigner)
+
+let addresses = (await fireblocks.vaults.getVaultAccountAssetAddressesPaginated({
+  vaultAccountId: fireblocksVaultAccountId,
+  assetId: fireblocksAssetId
+})).data.addresses
+
+// get the wallet address to use based on the assetId and vaultAccountId selected
+let wallet: string = ''
+if (addresses && addresses.length > 0) {
+  wallet = addresses[0].address as string
+}
+
+// use the getContract or any RPC interaction as usual with the VoidSigner 
+const signer = new ethers.VoidSigner(wallet, provider)
+
 ```

--- a/app/interactions.ts
+++ b/app/interactions.ts
@@ -4,7 +4,8 @@ import {
   SilentDataRollupRPCProvider,
   DEFAULT_SIGN_METHODS,
   deployContract,
-  getContract
+  getContract,
+  FireblocksSigner
 } from 'connector'
 
 import PrivateTokenArtifact from "../contracts/compiled/PrivateToken.json";
@@ -57,5 +58,6 @@ export {
   getTokenBalance,
   sendTransaction,
   SilentDataRollupRPCProvider,
+  FireblocksSigner,
   DEFAULT_SIGN_METHODS
 }

--- a/app/package.json
+++ b/app/package.json
@@ -15,6 +15,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
+    "@fireblocks/ts-sdk": "^2.0.0",
     "@inquirer/prompts": "^3.3.2",
     "connector": "workspace:connector",
     "dotenv": "^16.4.1",

--- a/connector/package.json
+++ b/connector/package.json
@@ -12,6 +12,7 @@
     "test": "jest --runInBand"
   },
   "dependencies": {
+    "@fireblocks/ts-sdk": "^2.0.0",
     "dotenv": "^16.4.1",
     "ethers": "^6.10.0",
     "node-fetch": "2"

--- a/connector/src/index.ts
+++ b/connector/src/index.ts
@@ -1,4 +1,4 @@
-import { SilentDataRollupRPCProvider } from "./provider";
+import { SilentDataRollupRPCProvider, FireblocksSigner } from "./provider";
 import { ethers, TransactionReceipt } from "ethers";
 
 const DEFAULT_SIGN_METHODS = [
@@ -53,4 +53,5 @@ export {
   waitTransactionReceipt,
   SilentDataRollupRPCProvider,
   DEFAULT_SIGN_METHODS,
+  FireblocksSigner
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -424,6 +424,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@fireblocks/ts-sdk@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@fireblocks/ts-sdk@npm:2.0.0"
+  dependencies:
+    axios: ^1.6.7
+    jsonwebtoken: 8.5.1
+    platform: 1.3.6
+    uuid: 8.3.2
+  checksum: 7480c06a2ca9d90e41da77e89e40d0ad92dc9a6d89fccee1cb8b7d9994db37052e8ed939ba43fdf5dfdbb713d6b2eb07ecc4ff67e6323eaf605ba973f6246b90
+  languageName: node
+  linkType: hard
+
 "@inquirer/checkbox@npm:^1.5.2":
   version: 1.5.2
   resolution: "@inquirer/checkbox@npm:1.5.2"
@@ -1254,9 +1266,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "app@workspace:app"
   dependencies:
+    "@fireblocks/ts-sdk": ^2.0.0
     "@inquirer/prompts": ^3.3.2
     "@types/node": ^20.11.16
-    connector: "workspace:^"
+    connector: "workspace:connector"
     dotenv: ^16.4.1
     ethers: ^6.10.0
     ts-node: ^10.9.2
@@ -1284,6 +1297,17 @@ __metadata:
   version: 0.4.0
   resolution: "asynckit@npm:0.4.0"
   checksum: 7b78c451df768adba04e2d02e63e2d0bf3b07adcd6e42b4cf665cb7ce899bedd344c69a1dcbce355b5f972d597b25aaa1c1742b52cffd9caccb22f348114f6be
+  languageName: node
+  linkType: hard
+
+"axios@npm:^1.6.7":
+  version: 1.7.2
+  resolution: "axios@npm:1.7.2"
+  dependencies:
+    follow-redirects: ^1.15.6
+    form-data: ^4.0.0
+    proxy-from-env: ^1.1.0
+  checksum: e457e2b0ab748504621f6fa6609074ac08c824bf0881592209dfa15098ece7e88495300e02cd22ba50b3468fd712fe687e629dcb03d6a3f6a51989727405aedf
   languageName: node
   linkType: hard
 
@@ -1427,6 +1451,13 @@ __metadata:
   dependencies:
     node-int64: ^0.4.0
   checksum: 9ba4dc58ce86300c862bffc3ae91f00b2a03b01ee07f3564beeeaf82aa243b8b03ba53f123b0b842c190d4399b94697970c8e7cf7b1ea44b61aa28c3526a4449
+  languageName: node
+  linkType: hard
+
+"buffer-equal-constant-time@npm:1.0.1":
+  version: 1.0.1
+  resolution: "buffer-equal-constant-time@npm:1.0.1"
+  checksum: 80bb945f5d782a56f374b292770901065bad21420e34936ecbe949e57724b4a13874f735850dd1cc61f078773c4fb5493a41391e7bda40d1fa388d6bd80daaab
   languageName: node
   linkType: hard
 
@@ -1635,10 +1666,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"connector@workspace:^, connector@workspace:connector":
+"connector@workspace:connector":
   version: 0.0.0-use.local
   resolution: "connector@workspace:connector"
   dependencies:
+    "@fireblocks/ts-sdk": ^2.0.0
     "@types/jest": ^29.5.11
     "@types/node-fetch": ^2.6.11
     dotenv: ^16.4.1
@@ -1770,6 +1802,15 @@ __metadata:
   version: 0.2.0
   resolution: "eastasianwidth@npm:0.2.0"
   checksum: 7d00d7cd8e49b9afa762a813faac332dee781932d6f2c848dc348939c4253f1d4564341b7af1d041853bc3f32c2ef141b58e0a4d9862c17a7f08f68df1e0f1ed
+  languageName: node
+  linkType: hard
+
+"ecdsa-sig-formatter@npm:1.0.11":
+  version: 1.0.11
+  resolution: "ecdsa-sig-formatter@npm:1.0.11"
+  dependencies:
+    safe-buffer: ^5.0.1
+  checksum: 207f9ab1c2669b8e65540bce29506134613dd5f122cccf1e6a560f4d63f2732d427d938f8481df175505aad94583bcb32c688737bb39a6df0625f903d6d93c03
   languageName: node
   linkType: hard
 
@@ -1975,6 +2016,16 @@ __metadata:
     locate-path: ^5.0.0
     path-exists: ^4.0.0
   checksum: 4c172680e8f8c1f78839486e14a43ef82e9decd0e74145f40707cc42e7420506d5ec92d9a11c22bd2c48fb0c384ea05dd30e10dd152fefeec6f2f75282a8b844
+  languageName: node
+  linkType: hard
+
+"follow-redirects@npm:^1.15.6":
+  version: 1.15.6
+  resolution: "follow-redirects@npm:1.15.6"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: a62c378dfc8c00f60b9c80cab158ba54e99ba0239a5dd7c81245e5a5b39d10f0c35e249c3379eae719ff0285fff88c365dd446fab19dee771f1d76252df1bbf5
   languageName: node
   linkType: hard
 
@@ -2879,6 +2930,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsonwebtoken@npm:8.5.1":
+  version: 8.5.1
+  resolution: "jsonwebtoken@npm:8.5.1"
+  dependencies:
+    jws: ^3.2.2
+    lodash.includes: ^4.3.0
+    lodash.isboolean: ^3.0.3
+    lodash.isinteger: ^4.0.4
+    lodash.isnumber: ^3.0.3
+    lodash.isplainobject: ^4.0.6
+    lodash.isstring: ^4.0.1
+    lodash.once: ^4.0.0
+    ms: ^2.1.1
+    semver: ^5.6.0
+  checksum: 93c9e3f23c59b758ac88ba15f4e4753b3749dfce7a6f7c40fb86663128a1e282db085eec852d4e0cbca4cefdcd3a8275ee255dbd08fcad0df26ad9f6e4cc853a
+  languageName: node
+  linkType: hard
+
+"jwa@npm:^1.4.1":
+  version: 1.4.1
+  resolution: "jwa@npm:1.4.1"
+  dependencies:
+    buffer-equal-constant-time: 1.0.1
+    ecdsa-sig-formatter: 1.0.11
+    safe-buffer: ^5.0.1
+  checksum: ff30ea7c2dcc61f3ed2098d868bf89d43701605090c5b21b5544b512843ec6fd9e028381a4dda466cbcdb885c2d1150f7c62e7168394ee07941b4098e1035e2f
+  languageName: node
+  linkType: hard
+
+"jws@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "jws@npm:3.2.2"
+  dependencies:
+    jwa: ^1.4.1
+    safe-buffer: ^5.0.1
+  checksum: f0213fe5b79344c56cd443428d8f65c16bf842dc8cb8f5aed693e1e91d79c20741663ad6eff07a6d2c433d1831acc9814e8d7bada6a0471fbb91d09ceb2bf5c2
+  languageName: node
+  linkType: hard
+
 "kleur@npm:^3.0.3":
   version: 3.0.3
   resolution: "kleur@npm:3.0.3"
@@ -2909,10 +2999,59 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.includes@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "lodash.includes@npm:4.3.0"
+  checksum: 71092c130515a67ab3bd928f57f6018434797c94def7f46aafa417771e455ce3a4834889f4267b17887d7f75297dfabd96231bf704fd2b8c5096dc4a913568b6
+  languageName: node
+  linkType: hard
+
+"lodash.isboolean@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "lodash.isboolean@npm:3.0.3"
+  checksum: b70068b4a8b8837912b54052557b21fc4774174e3512ed3c5b94621e5aff5eb6c68089d0a386b7e801d679cd105d2e35417978a5e99071750aa2ed90bffd0250
+  languageName: node
+  linkType: hard
+
+"lodash.isinteger@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "lodash.isinteger@npm:4.0.4"
+  checksum: 6034821b3fc61a2ffc34e7d5644bb50c5fd8f1c0121c554c21ac271911ee0c0502274852845005f8651d51e199ee2e0cfebfe40aaa49c7fe617f603a8a0b1691
+  languageName: node
+  linkType: hard
+
+"lodash.isnumber@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "lodash.isnumber@npm:3.0.3"
+  checksum: 913784275b565346255e6ae6a6e30b760a0da70abc29f3e1f409081585875105138cda4a429ff02577e1bc0a7ae2a90e0a3079a37f3a04c3d6c5aaa532f4cab2
+  languageName: node
+  linkType: hard
+
+"lodash.isplainobject@npm:^4.0.6":
+  version: 4.0.6
+  resolution: "lodash.isplainobject@npm:4.0.6"
+  checksum: 29c6351f281e0d9a1d58f1a4c8f4400924b4c79f18dfc4613624d7d54784df07efaff97c1ff2659f3e085ecf4fff493300adc4837553104cef2634110b0d5337
+  languageName: node
+  linkType: hard
+
+"lodash.isstring@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "lodash.isstring@npm:4.0.1"
+  checksum: eaac87ae9636848af08021083d796e2eea3d02e80082ab8a9955309569cb3a463ce97fd281d7dc119e402b2e7d8c54a23914b15d2fc7fff56461511dc8937ba0
+  languageName: node
+  linkType: hard
+
 "lodash.memoize@npm:4.x":
   version: 4.1.2
   resolution: "lodash.memoize@npm:4.1.2"
   checksum: 9ff3942feeccffa4f1fafa88d32f0d24fdc62fd15ded5a74a5f950ff5f0c6f61916157246744c620173dddf38d37095a92327d5fd3861e2063e736a5c207d089
+  languageName: node
+  linkType: hard
+
+"lodash.once@npm:^4.0.0":
+  version: 4.1.1
+  resolution: "lodash.once@npm:4.1.1"
+  checksum: d768fa9f9b4e1dc6453be99b753906f58990e0c45e7b2ca5a3b40a33111e5d17f6edf2f768786e2716af90a8e78f8f91431ab8435f761fef00f9b0c256f6d245
   languageName: node
   linkType: hard
 
@@ -3140,6 +3279,13 @@ __metadata:
   version: 2.1.2
   resolution: "ms@npm:2.1.2"
   checksum: 673cdb2c3133eb050c745908d8ce632ed2c02d85640e2edb3ace856a2266a813b30c613569bf3354fdf4ea7d1a1494add3bfa95e2713baa27d0c2c71fc44f58f
+  languageName: node
+  linkType: hard
+
+"ms@npm:^2.1.1":
+  version: 2.1.3
+  resolution: "ms@npm:2.1.3"
+  checksum: aa92de608021b242401676e35cfa5aa42dd70cbdc082b916da7fb925c542173e36bce97ea3e804923fe92c0ad991434e4a38327e15a1b5b5f945d66df615ae6d
   languageName: node
   linkType: hard
 
@@ -3387,6 +3533,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"platform@npm:1.3.6":
+  version: 1.3.6
+  resolution: "platform@npm:1.3.6"
+  checksum: 6f472a09c61d418c7e26c1c16d0bdc029549d512dbec6526216a1e59ec68100d07007d0097dcba69dddad883d6f2a83361b4bdfe0094a3d9a2af24158643d85e
+  languageName: node
+  linkType: hard
+
 "pretty-format@npm:^29.0.0, pretty-format@npm:^29.7.0":
   version: 29.7.0
   resolution: "pretty-format@npm:29.7.0"
@@ -3422,6 +3575,13 @@ __metadata:
     kleur: ^3.0.3
     sisteransi: ^1.0.5
   checksum: d8fd1fe63820be2412c13bfc5d0a01909acc1f0367e32396962e737cb2fc52d004f3302475d5ce7d18a1e8a79985f93ff04ee03007d091029c3f9104bffc007d
+  languageName: node
+  linkType: hard
+
+"proxy-from-env@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "proxy-from-env@npm:1.1.0"
+  checksum: ed7fcc2ba0a33404958e34d95d18638249a68c430e30fcb6c478497d72739ba64ce9810a24f53a7d921d0c065e5b78e3822759800698167256b04659366ca4d4
   languageName: node
   linkType: hard
 
@@ -3509,10 +3669,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"safe-buffer@npm:^5.0.1":
+  version: 5.2.1
+  resolution: "safe-buffer@npm:5.2.1"
+  checksum: b99c4b41fdd67a6aaf280fcd05e9ffb0813654894223afb78a31f14a19ad220bba8aba1cb14eddce1fcfb037155fe6de4e861784eb434f7d11ed58d1e70dd491
+  languageName: node
+  linkType: hard
+
 "safer-buffer@npm:>= 2.1.2 < 3, safer-buffer@npm:>= 2.1.2 < 3.0.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: cab8f25ae6f1434abee8d80023d7e72b598cf1327164ddab31003c51215526801e40b66c5e65d658a0af1e9d6478cadcb4c745f4bd6751f97d8644786c0978b0
+  languageName: node
+  linkType: hard
+
+"semver@npm:^5.6.0":
+  version: 5.7.2
+  resolution: "semver@npm:5.7.2"
+  bin:
+    semver: bin/semver
+  checksum: fb4ab5e0dd1c22ce0c937ea390b4a822147a9c53dbd2a9a0132f12fe382902beef4fbf12cf51bb955248d8d15874ce8cd89532569756384f994309825f10b686
   languageName: node
   linkType: hard
 
@@ -3973,6 +4149,15 @@ __metadata:
   bin:
     update-browserslist-db: cli.js
   checksum: 1e47d80182ab6e4ad35396ad8b61008ae2a1330221175d0abd37689658bdb61af9b705bfc41057fd16682474d79944fb2d86767c5ed5ae34b6276b9bed353322
+  languageName: node
+  linkType: hard
+
+"uuid@npm:8.3.2":
+  version: 8.3.2
+  resolution: "uuid@npm:8.3.2"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add Fireblocks support to sign raw transactions using a wallet as a service.

<img width="897" alt="Screenshot 2024-05-23 at 15 37 55" src="https://github.com/appliedblockchain/silent-data-rollup-quickstart/assets/1840393/f349dc70-4249-4a74-9d23-673fd253b4ac">

<img width="592" alt="Screenshot 2024-05-23 at 16 02 46" src="https://github.com/appliedblockchain/silent-data-rollup-quickstart/assets/1840393/5f47892f-776f-488d-936c-603ef55c4e80">

Changes:
- Add `@fireblocks/ts-sdk` to interact with Fireblocks;
- Update README with how to use Fireblocks and the configs needed;
- Add an example (`token-balance-fireblocks`) how to use the `FireblocksSigner`;
- Created and exported a new signer type for Fireblocks;
- Add the sign raw transaction feature using Fireblocks vault account;
- Add the integration basic tests;
