### PR TITLE
Fix clone and connect methods

### DIFF
--- a/packages/ethers-provider/src/types.ts
+++ b/packages/ethers-provider/src/types.ts
@@ -2,13 +2,20 @@ import {
   BaseConfig,
   NetworkName,
 } from "@appliedblockchain/silentdatarollup-core";
-import { JsonRpcApiProviderOptions, Signer } from "ethers";
+import { JsonRpcApiProviderOptions, JsonRpcSigner, Signer } from "ethers";
+
+// Create a custom signer that doesn't try to reconnect
+export class CustomSigner extends JsonRpcSigner {
+  connect(): CustomSigner {
+    return this;
+  }
+}
 
 export interface SilentDataRollupProviderConfig extends BaseConfig {
   rpcUrl: string;
   network?: NetworkName;
   chainId?: number;
   privateKey?: string;
-  signer?: Signer;
+  signer?: CustomSigner;
   options?: JsonRpcApiProviderOptions;
 }


### PR DESCRIPTION
Fixes [RD-855](https://appliedblockchain.atlassian.net/browse/RD-855)

- Signer connect extends JsonRpcSigner class which throws an exception if called without arguments.
- Cloning provider instance needs to be overridden to prevent the user from having to reinsert the signature.